### PR TITLE
Enable tests for multiple postgres versions

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -10,9 +10,13 @@ jobs:
           - '3.0.5'
           - '3.1.4'
           - '3.2.2'
+        postgres:
+          - '14'
+          - '15'
+          - '16'
     services:
       postgres:
-        image: postgres:11
+        image: postgres:${{ matrix.postgres }}
         ports:
           - 5432:5432
         env:


### PR DESCRIPTION
### What

We want to run CI not only against several ruby versions, but also using several Postgres versions