### PR TITLE
Propagate changes in memory when an impacted column is assigned

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,12 +32,32 @@ end
 
 The migration above generates the functions and triggers needed to keep `subscriptions.country_code` in sync with `companies.country`.
 
+You also need to update your models to reflect the syncroniaztion between their columns:
+
+```ruby
+class Company < ApplicationRecord
+  include ColumnSync::Model
+  
+  has_one :subscription
+
+  sync_column :country, to: :subscription, column: :country_code
+end
+
+class Subscription < ApplicationRecord
+  include ColumnSync::Model
+
+  belongs_to :company
+
+  sync_column :country_code, to: :company, column: :country
+end
+```
+
 ## Limitations
 
 - Each `sync_columns` statement can only sync a pair of columns. If the same column needs to be synchronized across multiple
   tables, multiple such statements will be needed.
 - The gem expects a `has_one` - `belongs_to` association between the models involved. It uses Rails reflections to understand
   the table names and column names involved.
-- The columns involved in the migration will be kept in sync via database triggers executed on row update.
-  It assumes the records are initially in sync, so it does **not** automatically sync values using any of the two columns involved.
+- It is assumed that the records are initially in sync, so it does **not** automatically sync values using any of the two 
+  columns involved.
 - It also does not sync values when a row is created, only when it is modified.

--- a/lib/column_sync.rb
+++ b/lib/column_sync.rb
@@ -6,6 +6,7 @@ require "fx"
 require "column_sync/version"
 require "column_sync/service"
 require "column_sync/migration"
+require "column_sync/model"
 
 module ColumnSync
   class Error < StandardError; end

--- a/lib/column_sync/model.rb
+++ b/lib/column_sync/model.rb
@@ -1,0 +1,48 @@
+require "active_support/concern"
+
+module ColumnSync
+  module Model
+    extend ActiveSupport::Concern
+
+    included do
+      scope :disabled, -> { where(disabled: true) }
+
+      before_update :propagate_changes
+
+      private
+
+      def propagate_changes
+        changes.each do |attribute, (_before, after)|
+          propagate_changes_in_memory(attribute, after)
+        end
+      end
+
+      def propagate_changes_in_memory(attribute, value)
+        self.class.columns_to_sync[attribute]&.each do |sync|
+          object = public_send(sync[:to])
+          next unless object
+
+          current_value = object.attributes[sync[:column].to_s]
+
+          object.public_send("#{sync[:column]}=", value) if current_value != value
+        end
+      end
+    end
+
+    class_methods do
+      attr_reader :columns_to_sync
+
+      def sync_column(column_name, to:, column:)
+        @columns_to_sync ||= {}
+        @columns_to_sync[column_name.to_s] ||= []
+        @columns_to_sync[column_name.to_s] << { to: to, column: column }
+
+        define_method("#{column_name}=") do |value|
+          super(value)
+
+          propagate_changes_in_memory(column_name.to_s, value)
+        end
+      end
+    end
+  end
+end

--- a/spec/support/dummy/.rspec
+++ b/spec/support/dummy/.rspec
@@ -1,1 +1,2 @@
 --require spec_helper
+--format documentation

--- a/spec/support/dummy/Gemfile
+++ b/spec/support/dummy/Gemfile
@@ -15,6 +15,7 @@ group :development, :test do
   gem "column_sync", path: "../../../../column_sync"
   gem "debug", platforms: %i[mri windows]
   gem "rspec-rails", "~> 6.1.0"
+  gem "pry"
 end
 
 group :development do

--- a/spec/support/dummy/Gemfile.lock
+++ b/spec/support/dummy/Gemfile.lock
@@ -89,6 +89,7 @@ GEM
     bootsnap (1.17.0)
       msgpack (~> 1.2)
     builder (3.2.4)
+    coderay (1.1.3)
     concurrent-ruby (1.2.2)
     connection_pool (2.4.1)
     crass (1.0.6)
@@ -127,6 +128,7 @@ GEM
       net-pop
       net-smtp
     marcel (1.0.2)
+    method_source (1.0.0)
     mini_mime (1.1.5)
     minitest (5.20.0)
     msgpack (1.7.2)
@@ -144,6 +146,9 @@ GEM
     nokogiri (1.15.5-x86_64-linux)
       racc (~> 1.4)
     pg (1.5.4)
+    pry (0.14.2)
+      coderay (~> 1.1)
+      method_source (~> 1.0)
     psych (5.1.1.1)
       stringio
     puma (6.4.0)
@@ -248,6 +253,7 @@ DEPENDENCIES
   importmap-rails
   jbuilder
   pg
+  pry
   puma (>= 5.0)
   rails (~> 7.1.2)
   rspec-rails (~> 6.1.0)

--- a/spec/support/dummy/app/models/company.rb
+++ b/spec/support/dummy/app/models/company.rb
@@ -1,3 +1,7 @@
 class Company < ApplicationRecord
+  include ColumnSync::Model
+  
   has_one :subscription
+
+  sync_column :country, to: :subscription, column: :country_code
 end

--- a/spec/support/dummy/app/models/subscription.rb
+++ b/spec/support/dummy/app/models/subscription.rb
@@ -1,3 +1,7 @@
 class Subscription < ApplicationRecord
+  include ColumnSync::Model
+
   belongs_to :company
+
+  sync_column :country_code, to: :company, column: :country
 end

--- a/spec/support/dummy/spec/rails_helper.rb
+++ b/spec/support/dummy/spec/rails_helper.rb
@@ -1,5 +1,6 @@
 # This file is copied to spec/ when you run 'rails generate rspec:install'
 require 'spec_helper'
+require 'pry'
 ENV['RAILS_ENV'] ||= 'test'
 require_relative '../config/environment'
 # Prevent database truncation if the environment is production

--- a/spec/support/dummy/spec/services/sync_spec.rb
+++ b/spec/support/dummy/spec/services/sync_spec.rb
@@ -11,31 +11,81 @@ RSpec.describe "column synchronization" do
     Subscription.create!(company: Company.third, country_code: "CA")
   end
 
-  it "syncs from company to subscription" do
-    expect(Subscription.first.country_code).to eq "US"
-    expect(Subscription.second.country_code).to eq "MX"
-    expect(Subscription.third.country_code).to eq "CA"
+  describe "sync from company to subscription" do
+    it "syncs the DB column" do
+      expect(Subscription.first.country_code).to eq "US"
+      expect(Subscription.second.country_code).to eq "MX"
+      expect(Subscription.third.country_code).to eq "CA"
 
-    Company.first.update!(country: "ES")
-    Company.second.update!(country: "AF")
-    Company.third.update!(country: "AD")
+      Company.first.update!(country: "ES")
+      Company.second.update!(country: "AF")
+      Company.third.update!(country: "AD")
 
-    expect(Subscription.first.country_code).to eq "ES"
-    expect(Subscription.second.country_code).to eq "AF"
-    expect(Subscription.third.country_code).to eq "AD"
+      expect(Subscription.first.country_code).to eq "ES"
+      expect(Subscription.second.country_code).to eq "AF"
+      expect(Subscription.third.country_code).to eq "AD"
+    end
+
+    it "updates the related object when persisted" do
+      company = Company.first
+      subscription = company.subscription
+
+      company.update!(country: "ES")
+      expect(subscription.country_code).to eq "ES"
+    end
+
+    it "updates the related object on change (when loaded)" do
+      company = Company.first
+      subscription = company.subscription
+
+      company.country = "ES"
+      expect(subscription.country_code).to eq "ES"
+    end
+
+    it "updates the related object on change (when not loaded)" do
+      company = Company.first
+
+      company.country = "ES"
+      expect(company.subscription.country_code).to eq "ES"
+    end
   end
 
-  it "syncs from subscription to company" do
-    expect(Company.first.country).to eq "US"
-    expect(Company.second.country).to eq "MX"
-    expect(Company.third.country).to eq "CA"
+  describe "sync from subscription to company" do
+    it "syncs the DB column" do
+      expect(Company.first.country).to eq "US"
+      expect(Company.second.country).to eq "MX"
+      expect(Company.third.country).to eq "CA"
 
-    Subscription.first.update!(country_code: "ES")
-    Subscription.second.update!(country_code: "AF")
-    Subscription.third.update!(country_code: "AD")
+      Subscription.first.update!(country_code: "ES")
+      Subscription.second.update!(country_code: "AF")
+      Subscription.third.update!(country_code: "AD")
 
-    expect(Company.first.country).to eq "ES"
-    expect(Company.second.country).to eq "AF"
-    expect(Company.third.country).to eq "AD"
+      expect(Company.first.country).to eq "ES"
+      expect(Company.second.country).to eq "AF"
+      expect(Company.third.country).to eq "AD"
+    end
+
+    it "updates the related object when persisted" do
+      subscription = Subscription.first
+      company = subscription.company
+
+      subscription.update!(country_code: "ES")
+      expect(company.country).to eq "ES"
+    end
+
+    it "updates the related object on change (when loaded)" do
+      subscription = Subscription.first
+      company = subscription.company
+
+      subscription.country_code = "ES"
+      expect(company.country).to eq "ES"
+    end
+
+    it "updates the related object on change (when not loaded)" do
+      subscription = Subscription.first
+
+      subscription.country_code = "ES"
+      expect(subscription.company.country).to eq "ES"
+    end
   end
 end


### PR DESCRIPTION
### What

We want to make the sync as transparent as possible for the user. In this PR we are syncing the attribute changes in memory, even before the object has been persisted.